### PR TITLE
Add sanity check for python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 # This workflow runs the `check_install` script with a few different versions of Python to make sure everything's in order.
 # Based on: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python version sanity check
+name: CI
 
 on:
   push:
@@ -10,11 +10,12 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
+  sanity:
+    name: sanity check (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -22,13 +23,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - uses: actions/setup-java@v1
       with:
-        java-version: '1.8'
-    - name: Make dummy empty lab dir
-      run: mkdir -p ../labs
-    - name: Install dependencies
+        java-package: jre
+        java-version: '8'
+    - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Test
-      run: |
-        python check_install.py
+    - name: Mock assignment dirs
+      run: mkdir -p ../labs
+    - name: Check install
+      run: python check_install.py

--- a/.github/workflows/python-version-check.yml
+++ b/.github/workflows/python-version-check.yml
@@ -1,0 +1,34 @@
+# This workflow runs the `check_install` script with a few different versions of Python to make sure everything's in order.
+# Based on: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python version sanity check
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.7', '3.8', '3.9']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - uses: actions/setup-java@v1
+      with:
+        java-version: '1.8'
+    - name: Make dummy empty lab dir
+      run: mkdir -p ../labs
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test
+      run: |
+        python check_install.py


### PR DESCRIPTION
This adds a github action that runs `check_install` with Python 3.6 through 3.9 to make sure everything works.